### PR TITLE
Version 1014

### DIFF
--- a/TA-ms-teams-alert-action/app.manifest
+++ b/TA-ms-teams-alert-action/app.manifest
@@ -1,11 +1,11 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "2.0.0",
   "info": {
     "title": "MS Teams alert action",
     "id": {
       "group": null,
       "name": "TA-ms-teams-alert-action",
-      "version": "1.0.13"
+      "version": "1.0.14"
     },
     "author": [
       {

--- a/TA-ms-teams-alert-action/app.manifest
+++ b/TA-ms-teams-alert-action/app.manifest
@@ -34,17 +34,15 @@
     },
     "releaseNotes": {
       "name": null,
-      "text": null,
-      "uri":"https://ta-ms-teams-alert-action.readthedocs.io/en/latest/releasenotes.html"
+      "text": "./README.txt",
+      "uri": "https://ta-ms-teams-alert-action.readthedocs.io/en/latest/releasenotes.html"
     }
   },
-  "dependencies": {
-  },
-  "tasks": [],
-  "inputGroups": {
-  },
-  "incompatibleApps": {
-  },
+  "dependencies": null,
+  "tasks": null,
+  "inputGroups": null,
+  "incompatibleApps": null,
+  "platformRequirements": null,
   "supportedDeployments": [
     "_standalone",
     "_distributed",

--- a/TA-ms-teams-alert-action/default/app.conf
+++ b/TA-ms-teams-alert-action/default/app.conf
@@ -7,7 +7,7 @@ build = 1
 
 [launcher]
 author = Guilhem Marchand
-version = 1.0.13
+version = 1.0.14
 description = This addon allows publishing messages to Microsoft Teams channels with markdown formatting.
 
 [ui]

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,13 @@
 Release notes
 #############
 
+Version 1.0.14
+==============
+
+- Fix: Issue #20 Provides an option to disable SSL certificate verification (but enabled by default) to avoid failures with environments using SSL interception
+- Feature: Issue #17 Provides an option on a per alert basis to allow ordering of the fields in the message by using the fields list ordering rather than alphabetical ordering
+- Fix: SLIM error for app vetting due to the introduction of the targetWorkloads in app.manifest which requires version 2.0.0 of the app.manifest schema
+
 Version 1.0.13
 ==============
 


### PR DESCRIPTION
Version 1.0.14
==============

- Fix: Issue #20 Provides an option to disable SSL certificate verification (but enabled by default) to avoid failures with environments using SSL interception
- Feature: Issue #17 Provides an option on a per alert basis to allow ordering of the fields in the message by using the fields list ordering rather than alphabetical ordering
- Fix: SLIM error for app vetting due to the introduction of the targetWorkloads in app.manifest which requires version 2.0.0 of the app.manifest schema
