### PR TITLE
Add help-link class, open in a new window, and external icon.

### DIFF
--- a/TA-ms-teams-alert-action/default/data/ui/alerts/ms_teams_publish_to_channel.html
+++ b/TA-ms-teams-alert-action/default/data/ui/alerts/ms_teams_publish_to_channel.html
@@ -117,7 +117,7 @@ Each field has to be a field resulting from the search.
     <div class="controls">
 	<input type="text" name="action.ms_teams_publish_to_channel.param.alert_ms_teams_potential_postaction_body" id="ms_teams_publish_to_channel_alert_ms_teams_potential_postaction_body"/>
                 <span class="help-block">
-                    The body of the POST request. (optional, see: <a href="https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#httppost-action">Microsoft actionable message card reference</a>)
+                    The body of the POST request. (optional, see: <a class="help-link" href="https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#httppost-action" target="_blank">Microsoft actionable message card reference<i class="icon-external"></i></a>)
                 </span>
     </div>
 </div>


### PR DESCRIPTION
Follow example by Splunk built alerts, and lots of others. Open external help in a new window, to avoid losing settings that you have filled out.