### PR TITLE
Version 1.1.7

### DIFF
--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,12 @@
 Release notes
 #############
 
+Version 1.1.7
+=============
+
+- Splunk UCC, SDK and other librairies refresh to very last versions
+- Switch http.status_code verification from an explicit list of 2* codes to allow any 2* code, this change is to allow a workaround using Power Automate Flow to allow the deprecation of message cards by Microsoft.
+
 Version 1.1.6
 =============
 

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -99,41 +99,7 @@
                     "title": "Proxy"
                 },
                 {
-                    "name": "logging",
-                    "entity": [
-                        {
-                            "type": "singleSelect",
-                            "label": "Log level",
-                            "options": {
-                                "disableSearch": true,
-                                "autoCompleteFields": [
-                                    {
-                                        "value": "DEBUG",
-                                        "label": "DEBUG"
-                                    },
-                                    {
-                                        "value": "INFO",
-                                        "label": "INFO"
-                                    },
-                                    {
-                                        "value": "WARNING",
-                                        "label": "WARNING"
-                                    },
-                                    {
-                                        "value": "ERROR",
-                                        "label": "ERROR"
-                                    },
-                                    {
-                                        "value": "CRITICAL",
-                                        "label": "CRITICAL"
-                                    }
-                                ]
-                            },
-                            "defaultValue": "INFO",
-                            "field": "loglevel"
-                        }
-                    ],
-                    "title": "Logging"
+                    "type": "loggingTab"
                 },
                 {
                     "name": "additional_parameters",
@@ -199,7 +165,7 @@
             "name": "ms_teams_publish_to_channel",
             "label": "MS teams publish to channel",
             "description": "Publish a message to a Microsoft Teams channel",
-            "activeResponse": {
+            "adaptiveResponse": {
                 "task": [
                     "Create",
                     "Update",
@@ -223,7 +189,8 @@
                     }
                 ],
                 "drilldownUri": "search?q=search%20index%3D_internal%20OR%20index%3Dcim_modaction%20sourcetype%3Dta:msteams:alert:log&earliest=0&latest=",
-                "sourcetype": "ta:msteams:alert:log"
+                "sourcetype": "ta:msteams:alert:log",
+                "supportsCloud": true
             },
             "entity": [
                 {
@@ -407,9 +374,9 @@
     "meta": {
         "name": "TA-ms-teams-alert-action",
         "restRoot": "ta_ms_teams_alert_action",
-        "version": "1.1.6",
+        "version": "1.1.7",
         "displayName": "MS Teams alert action",
-        "schemaVersion": "0.0.3",
-        "_uccVersion": "5.39.1"
+        "schemaVersion": "0.0.7",
+        "_uccVersion": "5.48.2"
     }
 }

--- a/package/bin/ta_ms_teams_alert_action/modalert_ms_teams_publish_to_channel_helper.py
+++ b/package/bin/ta_ms_teams_alert_action/modalert_ms_teams_publish_to_channel_helper.py
@@ -569,7 +569,7 @@ def process_event(helper, *args, **kwargs):
                     use_proxy=opt_use_proxy,
                 )
                 # No http exception, but http post was not successful
-                if response.status_code not in (200, 201, 204):
+                if not (200 <= response.status_code < 300):
 
                     helper.log_error(
                         "Microsoft Teams publish to channel has failed!. "
@@ -613,7 +613,7 @@ def process_event(helper, *args, **kwargs):
                     response = requests.post(
                         record_url, headers=headers, data=record, verify=False
                     )
-                    if response.status_code not in (200, 201, 204):
+                    if not (200 <= response.status_code < 300):
                         helper.log_error(
                             "KVstore saving has failed!. url={}, data={}, HTTP Error={}, "
                             "content={}".format(
@@ -668,7 +668,7 @@ def process_event(helper, *args, **kwargs):
                 response = requests.post(
                     record_url, headers=headers, data=record, verify=False
                 )
-                if response.status_code not in (200, 201, 204):
+                if not (200 <= response.status_code < 300):
                     helper.log_error(
                         "KVstore saving has failed!. url={}, data={}, HTTP Error={}, "
                         "content={}".format(

--- a/package/bin/ta_ms_teams_alert_action/modalert_ms_teams_publish_to_channel_replay_helper.py
+++ b/package/bin/ta_ms_teams_alert_action/modalert_ms_teams_publish_to_channel_replay_helper.py
@@ -134,7 +134,7 @@ def process_event(helper, *args, **kwargs):
             )
 
             # No http exception, but http post was not successful
-            if response.status_code not in (200, 201, 204):
+            if not (200 <= response.status_code < 300):
                 helper.log_error(
                     "Microsoft Teams publish to channel has failed!. "
                     "url={}, data={}, HTTP Error={}, HTTP Reason={}, HTTP content={}".format(
@@ -181,7 +181,7 @@ def process_event(helper, *args, **kwargs):
                 response = requests.post(
                     record_url, headers=headers, data=record, verify=False
                 )
-                if response.status_code not in (200, 201, 204):
+                if not (200 <= response.status_code < 300):
                     helper.log_error(
                         "KVstore saving has failed!. url={}, data={}, HTTP Error={}, "
                         "content={}".format(
@@ -213,7 +213,7 @@ def process_event(helper, *args, **kwargs):
                 # Splunk Cloud vetting note, this communication is a localhost communication to splunkd
                 # and does not have to be verified
                 response = requests.delete(record_url, headers=headers, verify=False)
-                if response.status_code not in (200, 201, 204):
+                if not (200 <= response.status_code < 300):
                     helper.log_error(
                         "KVstore delete operation has failed!. url={}, HTTP Error={}, "
                         "content={}".format(
@@ -265,7 +265,7 @@ def process_event(helper, *args, **kwargs):
             response = requests.post(
                 record_url, headers=headers, data=record, verify=False
             )
-            if response.status_code not in (200, 201, 204):
+            if not (200 <= response.status_code < 300):
                 helper.log_error(
                     "KVstore saving has failed!. url={}, data={}, HTTP Error={}, "
                     "content={}".format(
@@ -314,7 +314,7 @@ def process_event(helper, *args, **kwargs):
         # Splunk Cloud vetting note, this communication is a localhost communication to splunkd and
         # does not have to be verified
         response = requests.post(record_url, headers=headers, data=record, verify=False)
-        if response.status_code not in (200, 201, 204):
+        if not (200 <= response.status_code < 300):
             helper.log_error(
                 "KVstore saving has failed!. url={}, data={}, HTTP Error={}, "
                 "content={}".format(
@@ -352,7 +352,7 @@ def process_event(helper, *args, **kwargs):
         # Splunk Cloud vetting note, this communication is a localhost communication to splunkd and
         # does not have to be verified
         response = requests.delete(record_url, headers=headers, verify=False)
-        if response.status_code not in (200, 201, 204):
+        if not (200 <= response.status_code < 300):
             helper.log_error(
                 "KVstore delete operation has failed!. url={}, HTTP Error={}, "
                 "content={}".format(record_url, response.status_code, response.text)

--- a/package/lib/requirements.txt
+++ b/package/lib/requirements.txt
@@ -1,2 +1,1 @@
 splunktaucclib>=6.2.0
-requests>=2.32.3

--- a/package/lib/requirements.txt
+++ b/package/lib/requirements.txt
@@ -1,1 +1,2 @@
 splunktaucclib>=6.2.0
+requests>=2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 splunk-add-on-ucc-framework>=5.44.0
+requests>=2.32.3

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.1.6",
+  "version": "1.1.7",
   "appID": "TA-ms-teams-alert-action"
 }


### PR DESCRIPTION
- Splunk UCC, SDK and other librairies refresh to very last versions
- Switch http.status_code verification from an explicit list of 2* codes to allow any 2* code, this change is to allow a workaround using Power Automate Flow to allow the deprecation of message cards by Microsoft.
- New alert action for MS workbook